### PR TITLE
Fix 404 in edit link

### DIFF
--- a/src/components/EditOnGithubLink.vue
+++ b/src/components/EditOnGithubLink.vue
@@ -21,7 +21,7 @@ export default {
     props: ['path'],
     computed: {
         editLink() {
-            return `${this.$static.metadata.githubUrl}/edit/master/content/${this.path}`
+            return `${this.$static.metadata.githubUrl}/edit/master/content/docs/${this.path}`
         }
     }
 }


### PR DESCRIPTION
At the moment when clicking on "Edit this page on GitHub" in the documentation it is resulting in showing a 404 page on GitHub.