### PR TITLE
Add documentation to limit orderline quantity

### DIFF
--- a/content/docs/core/1.2.0/how-to-guides/limit-orderline-quantity.md
+++ b/content/docs/core/1.2.0/how-to-guides/limit-orderline-quantity.md
@@ -3,7 +3,7 @@ title: Limit Orderline Quantity in Vendr
 description: How-To Guide to limit orderline quantity in Vendr, the eCommerce solution for Umbraco v8+
 ---
 
-In this guide we wil be looking at Validation events in Vendr to be able to limit orderline quantity based on the existing stock value on the product and the existing quantities of the product in the cart.
+In this guide we will be looking at Validation events in Vendr to be able to limit orderline quantity based on the existing stock value on the product and the existing quantities of the product in the cart.
 
 ## ProductAddValidationHandler
 

--- a/content/docs/core/1.2.0/how-to-guides/limit-orderline-quantity.md
+++ b/content/docs/core/1.2.0/how-to-guides/limit-orderline-quantity.md
@@ -1,9 +1,9 @@
 ---
-title: Limit Orderline Quantity in Vendr
-description: How-To Guide to limit orderline quantity in Vendr, the eCommerce solution for Umbraco v8+
+title: Limit Order Line Quantity in Vendr
+description: How-To Guide to limit order line quantity in Vendr, the eCommerce solution for Umbraco v8+
 ---
 
-In this guide we will be looking at Validation events in Vendr to be able to limit orderline quantity based on the existing stock value on the product and the existing quantities of the product in the cart.
+In this guide we will be looking at Validation events in Vendr to be able to limit order line quantity based on the existing stock value on the product and the existing quantities of the product in the cart.
 
 ## ProductAddValidationHandler
 
@@ -38,7 +38,7 @@ public class ProductAddValidationHandler : ValidationEventHandlerBase<ValidateOr
 
 ## OrderLineQuantityValidationHandler
 
-Furthermore when changing orderline quantity on cart page, we need to ensure to quantities being changed to are in stock.
+Furthermore when changing order line quantity on cart page, we need to ensure to quantities being changed to are in stock.
 
 ````csharp
 public class OrderLineQuantityValidationHandler : ValidationEventHandlerBase<ValidateOrderLineQuantityChange>

--- a/content/docs/core/1.2.0/how-to-guides/limit-orderline-quantity.md
+++ b/content/docs/core/1.2.0/how-to-guides/limit-orderline-quantity.md
@@ -64,3 +64,23 @@ public class OrderLineQuantityValidationHandler : ValidationEventHandlerBase<Val
 }
 
 ````
+
+## Register event handlers
+
+Finally we need to register the Vendr event handlers in our `StoreComposer`.
+
+````csharp
+[ComposeAfter(typeof(VendrWebComposer))]
+public class StoreComposer : IUserComposer
+{
+    public void Compose(Composition composition)
+    {
+        // Register event handlers
+        composition.WithValidationEvent<ValidateOrderProductAdd>()
+            .RegisterHandler<ProductAddValidationHandler>();
+
+        composition.WithValidationEvent<ValidateOrderLineQuantityChange>()
+            .RegisterHandler<OrderLineQuantityValidationHandler>();
+    }
+}
+````

--- a/content/docs/core/1.2.0/how-to-guides/limit-orderline-quantity.md
+++ b/content/docs/core/1.2.0/how-to-guides/limit-orderline-quantity.md
@@ -1,0 +1,66 @@
+---
+title: Limit Orderline Quantity in Vendr
+description: How-To Guide to limit orderline quantity in Vendr, the eCommerce solution for Umbraco v8+
+---
+
+In this guide we wil be looking at Validation events in Vendr to be able to limit orderline quantity based on the existing stock value on the product and the existing quantities of the product in the cart.
+
+## ProductAddValidationHandler
+
+When adding a product to cart we need to verify the product is in stock and the customer not already has the remaining quantities in cart.
+
+````csharp
+public class ProductAddValidationHandler : ValidationEventHandlerBase<ValidateOrderProductAdd>
+{
+    private readonly IUmbracoContextAccessor _context;
+
+    public ProductAddValidationHandler(IUmbracoContextAccessor context)
+    {
+        _context = context;
+    }
+
+    public override void Validate(ValidateOrderProductAdd evt)
+    {
+        var order = evt.Order;
+        var productReference = evt.ProductReference;
+
+        var product = _context.UmbracoContext.Content.GetById(new Guid(productReference));
+        var stock = product.Value<decimal?>("stock");
+
+        var totalQuantities = order?.OrderLines.Where(x => x.ProductReference == productReference).Sum(x => x.Quantity) ?? 0;
+
+        if (stock.HasValue && totalQuantities >= stock.Value)
+            evt.Fail($"Only {stock} quantities can be purchased for {productReference}");
+    }
+}
+
+````
+
+## OrderLineQuantityValidationHandler
+
+Furthermore when changing orderline quantity on cart page, we need to ensure to quantities being changed to are in stock.
+
+````csharp
+public class OrderLineQuantityValidationHandler : ValidationEventHandlerBase<ValidateOrderLineQuantityChange>
+{
+    private readonly IUmbracoContextAccessor _context;
+
+    public OrderLineQuantityValidationHandler(IUmbracoContextAccessor context)
+    {
+        _context = context;
+    }
+
+    public override void Validate(ValidateOrderLineQuantityChange evt)
+    {
+        var orderLine = evt.OrderLine;
+        var productReference = orderLine.ProductReference;
+
+        var product = _context.UmbracoContext.Content.GetById(new Guid(productReference));
+        var stock = product.Value<decimal?>("stock");
+
+        if (stock.HasValue && evt.Quantity.To > stock.Value)
+            evt.Fail($"Only {stock} quantities can be purchased for {productReference}.");
+    }
+}
+
+````

--- a/content/docs/core/1.2.0/how-to-guides/limit-orderline-quantity.md
+++ b/content/docs/core/1.2.0/how-to-guides/limit-orderline-quantity.md
@@ -59,7 +59,7 @@ public class OrderLineQuantityValidationHandler : ValidationEventHandlerBase<Val
         var stock = product.Value<decimal?>("stock");
 
         if (stock.HasValue && evt.Quantity.To > stock.Value)
-            evt.Fail($"Only {stock} quantities can be purchased for {productReference}.");
+            evt.Fail($"Only {stock} quantities can be purchased for {productReference}");
     }
 }
 

--- a/content/docs/core/1.2.0/how-to-guides/limit-orderline-quantity.md
+++ b/content/docs/core/1.2.0/how-to-guides/limit-orderline-quantity.md
@@ -1,5 +1,5 @@
 ---
-title: Limit Order Line Quantity in Vendr
+title: Limit Order Line Quantity
 description: How-To Guide to limit order line quantity in Vendr, the eCommerce solution for Umbraco v8+
 ---
 

--- a/content/docs/core/1.2.0/links.yml
+++ b/content/docs/core/1.2.0/links.yml
@@ -20,7 +20,7 @@
   items:
     - title: Overview
       link: /how-to-guides/
-    - title: Limit Order Line Quantity in Vendr
+    - title: Limit Order Line Quantity
       link: /how-to-guides/limit-orderline-quantity/
 
 - title: Key Concepts

--- a/content/docs/core/1.2.0/links.yml
+++ b/content/docs/core/1.2.0/links.yml
@@ -20,6 +20,8 @@
   items:
     - title: Overview
       link: /how-to-guides/
+    - title: Limit Order Line Quantity in Vendr
+      link: /how-to-guides/limit-orderline-quantity/
 
 - title: Key Concepts
   items:


### PR DESCRIPTION
This PR add a how-to documentation for limiting orderline quantity on product add and orderline quantity change based on the product stock value and the current quantities of the product in cart.