### PR TITLE
Typos fix in how to guides

### DIFF
--- a/content/docs/core/1.0.0/how-to-guides/README.md
+++ b/content/docs/core/1.0.0/how-to-guides/README.md
@@ -3,6 +3,6 @@ title: How-To Guides
 description: How-to Guides on how to perform specific tasks in Vendr, the eCommerce solution for Umbraco v8+
 ---
 
-In this section we will provide a series of How-Top Guides, showcasing how to perform specific task within Vendr.
+In this section we will provide a series of How-To Guides, showcasing how to perform specific task within Vendr.
 
 <work-in-progress />

--- a/content/docs/core/1.2.0/how-to-guides/README.md
+++ b/content/docs/core/1.2.0/how-to-guides/README.md
@@ -3,6 +3,6 @@ title: How-To Guides
 description: How-to Guides on how to perform specific tasks in Vendr, the eCommerce solution for Umbraco v8+
 ---
 
-In this section we will provide a series of How-Top Guides, showcasing how to perform specific task within Vendr.
+In this section we will provide a series of How-To Guides, showcasing how to perform specific task within Vendr.
 
 <work-in-progress />


### PR DESCRIPTION
Fixed typos in docs/core 1.0.0 and 1.2.0 how to guide readme file.