### PR TITLE
Method name typos in unit of work section

### DIFF
--- a/content/docs/core/1.0.0/key-concepts/unit-of-work.md
+++ b/content/docs/core/1.0.0/key-concepts/unit-of-work.md
@@ -21,7 +21,7 @@ using(var uow = _uowProvider.Create())
 
 ````
 
-The anatomy of a Unit of Work then is a `using` statement, in the constructor for which we create our `uow` instance by calling the `Create()` method of the `IUnitOfWorkProvider`. Then, inside the using statement, we perform our tasks and confirm the Unit of Work as complete by calling `uow.Compelte()`. If we fail to call `uow.Complete()` either due to forgetting to add the `uow.Complete()` call, or due to an exception in our code, then any write operations that occur within that code block will **NOT** be persisted to the database.
+The anatomy of a Unit of Work then is a `using` statement, in the constructor for which we create our `uow` instance by calling the `Create()` method of the `IUnitOfWorkProvider`. Then, inside the using statement, we perform our tasks and confirm the Unit of Work as complete by calling `uow.Complete()`. If we fail to call `uow.Complete()` either due to forgetting to add the `uow.Complete()` call, or due to an exception in our code, then any write operations that occur within that code block will **NOT** be persisted to the database.
 
 ## Unit of Work Best Practice
 

--- a/content/docs/core/1.2.0/key-concepts/unit-of-work.md
+++ b/content/docs/core/1.2.0/key-concepts/unit-of-work.md
@@ -21,7 +21,7 @@ using(var uow = _uowProvider.Create())
 
 ````
 
-The anatomy of a Unit of Work then is a `using` statement, in the constructor for which we create our `uow` instance by calling the `Create()` method of the `IUnitOfWorkProvider`. Then, inside the using statement, we perform our tasks and confirm the Unit of Work as complete by calling `uow.Compelte()`. If we fail to call `uow.Complete()` either due to forgetting to add the `uow.Complete()` call, or due to an exception in our code, then any write operations that occur within that code block will **NOT** be persisted to the database.
+The anatomy of a Unit of Work then is a `using` statement, in the constructor for which we create our `uow` instance by calling the `Create()` method of the `IUnitOfWorkProvider`. Then, inside the using statement, we perform our tasks and confirm the Unit of Work as complete by calling `uow.Complete()`. If we fail to call `uow.Complete()` either due to forgetting to add the `uow.Complete()` call, or due to an exception in our code, then any write operations that occur within that code block will **NOT** be persisted to the database.
 
 ## Unit of Work Best Practice
 


### PR DESCRIPTION
Method name typos under key concepts > unit of work section.
"uow.**Compelte()**" corrected to "uow.**Complete()**"