### PR TITLE
Service interface for price freezing name and method names updated

### DIFF
--- a/content/docs/core/1.0.0/key-concepts/price-freezing.md
+++ b/content/docs/core/1.0.0/key-concepts/price-freezing.md
@@ -11,18 +11,18 @@ By default a product's price is Frozen from the point a product is added to the 
 
 There are times when you may wish to control when a frozen price should expire, such as if a product was incorrectly priced, or if you have some pre-defined rules as to how long an Order session should be allowed to maintain a frozen price for.
 
-In these occasions you can force frozen prices to expire by using the `IFrozenPriceService` and its `Thaw` method.
+In these occasions you can force frozen prices to expire by using the `IPriceFreezerService` and its `ThawPrices` method.
 
 All frozen prices have an `OrderId` property and a `Key` that uniquely identifies them. For product prices, this key consists of a generated token of the following format `{StoreId}_{OrderId}_{ProductReference}`. In addition, the product prices Currency and date of the freeze are also tracked. It is important to know these details as we can use all of these attributes to target which prices we wish to thaw.
 
 For example, to thaw all prices for a product with the reference `c0296b75-1764-4f62-b59c-7005c2348fdd` we could call:
 
 ````csharp
-_frozenPriceService.Thaw(partialKey: "c0296b75-1764-4f62-b59c-7005c2348fdd");
+_priceFreezerService.ThawPrices(partialKey: "c0296b75-1764-4f62-b59c-7005c2348fdd");
 ````
 
 Or to thaw all prices for a given Currency that are greater than 30 days old we could call:
 
 ````csharp
-_frozenPriceService.Thaw(currencyId: currency.Id, olderThan: DateTime.Now.AddDays(-30));
+_priceFreezerService.ThawPrices(currencyId: currency.Id, olderThan: DateTime.Now.AddDays(-30));
 ````

--- a/content/docs/core/1.2.0/key-concepts/price-freezing.md
+++ b/content/docs/core/1.2.0/key-concepts/price-freezing.md
@@ -11,18 +11,18 @@ By default a product's price is Frozen from the point a product is added to the 
 
 There are times when you may wish to control when a frozen price should expire, such as if a product was incorrectly priced, or if you have some pre-defined rules as to how long an Order session should be allowed to maintain a frozen price for.
 
-In these occasions you can force frozen prices to expire by using the `IFrozenPriceService` and its `Thaw` method.
+In these occasions you can force frozen prices to expire by using the `IPriceFreezerService` and its `ThawPrices` method.
 
 All frozen prices have an `OrderId` property and a `Key` that uniquely identifies them. For product prices, this key consists of a generated token of the following format `{StoreId}_{OrderId}_{ProductReference}`. In addition, the product prices Currency and date of the freeze are also tracked. It is important to know these details as we can use all of these attributes to target which prices we wish to thaw.
 
 For example, to thaw all prices for a product with the reference `c0296b75-1764-4f62-b59c-7005c2348fdd` we could call:
 
 ````csharp
-_frozenPriceService.Thaw(partialKey: "c0296b75-1764-4f62-b59c-7005c2348fdd");
+_priceFreezerService.ThawPrices(partialKey: "c0296b75-1764-4f62-b59c-7005c2348fdd");
 ````
 
 Or to thaw all prices for a given Currency that are greater than 30 days old we could call:
 
 ````csharp
-_frozenPriceService.Thaw(currencyId: currency.Id, olderThan: DateTime.Now.AddDays(-30));
+_priceFreezerService.ThawPrices(currencyId: currency.Id, olderThan: DateTime.Now.AddDays(-30));
 ````


### PR DESCRIPTION
'IFrozenPriceService' name was changed to 'IPriceFreezerService' and its 'Thaw' method was renamed to 'ThawPrices'.