### PR TITLE
Remove "One Time" from heading

### DIFF
--- a/content/docs/payment-providers/quickpay/1.0.0/quickpay-v10-checkout/README.md
+++ b/content/docs/payment-providers/quickpay/1.0.0/quickpay-v10-checkout/README.md
@@ -1,5 +1,5 @@
 ---
-title: QuickPay V10 (One Time)
+title: QuickPay V10
 description: Documentation for the QuickPay V10 (One Time) payment provider for Vendr, the eCommerce solution for Umbraco v8+
 ---
 

--- a/content/docs/payment-providers/reepay/1.0.0/reepay-checkout/README.md
+++ b/content/docs/payment-providers/reepay/1.0.0/reepay-checkout/README.md
@@ -1,5 +1,5 @@
 ---
-title: Reepay Checkout (One Time)
+title: Reepay Checkout
 description: Documentation for the Reepay Checkout (One Time) payment provider for Vendr, the eCommerce solution for Umbraco v8+
 ---
 


### PR DESCRIPTION
Just some minor changes to remove "One Time" from heading and since I didn't added this for Yourpay.
I think it is fine the description mention "One Time".

@mattbrailsford not sure if want to get rid of "One Time" for Stripe v1. The url and description would remain the same.
https://vendr.net/docs/payment-providers/stripe/1-0-0/stripe-checkout-onetime/