### PR TITLE
add key for additionalInfo element

### DIFF
--- a/content/docs/core/1.3.0/key-concepts/order-editor-config.md
+++ b/content/docs/core/1.3.0/key-concepts/order-editor-config.md
@@ -52,7 +52,7 @@ And example of an Order Editor config file would look something like this:
         internalNotes: { alias: "notes", label: "Internal Notes" }
     },
     additionalInfo: [
-        { alias: "ipAddress", label: "IP Address", isReadOnly: true }
+        ipAddress: { alias: "ipAddress", label: "IP Address", isReadOnly: true }
     ]
 }
 ````


### PR DESCRIPTION
It seems the current version of Vendr requires a key on the additionalInfo properties:

i.e. from:
```
additionalInfo: [
        { alias: "ipAddress", label: "IP Address", isReadOnly: true }
    ]
```
to
```
additionalInfo: [
        ipAddress: { alias: "ipAddress", label: "IP Address", isReadOnly: true }
    ]
```