### PR TITLE
Updated deprecated example on Discount rules & rewards page

### DIFF
--- a/content/docs/core/1.4.0/key-concepts/discount-rules-and-rewards.md
+++ b/content/docs/core/1.4.0/key-concepts/discount-rules-and-rewards.md
@@ -149,10 +149,10 @@ Reward Providers then have a `CalculateReward` method which accepts a `DiscountR
 
 ````csharp
 // Add a shipping total discount
-result.ShippingTotalPriceDiscounts.Add(new AppliedDiscount(ctx.Discount, price));
+result.ShippingTotalPriceAdjustments.Add(new DiscountAdjustment(ctx.Discount, price));
 
 // Add a subtotal discount
-result.SubtotalPriceDiscounts.Add(new AppliedDiscount(ctx.Discount, price));
+result.SubtotalPriceAdjustments.Add(new DiscountAdjustment(ctx.Discount, price));
 ````
 
 ## Common Features


### PR DESCRIPTION
Changed to examples from the old Discount based (per 1.4.0) way to the new way with PriceAdjustments.