### PR TITLE
Spelling fixes

### DIFF
--- a/content/core/1.7.0/reference/vendr-core-models/productattributepresetreadonly.md
+++ b/content/core/1.7.0/reference/vendr-core-models/productattributepresetreadonly.md
@@ -35,7 +35,7 @@ public string Alias { get; }
 
 #### AllowedAttributes
 
-Gets the list of allowed Product Attribtues for this Product Attribute Preset
+Gets the list of allowed Product Attributes for this Product Attribute Preset
 
 ```csharp
 public IReadOnlyCollection<AllowedProductAttribute> AllowedAttributes { get; }

--- a/content/core/1.7.0/reference/vendr-core-models/productvariantcollection.md
+++ b/content/core/1.7.0/reference/vendr-core-models/productvariantcollection.md
@@ -25,7 +25,7 @@ public ProductVariantCollection(Guid storeId, IList<ProductVariantItem> list)
 
 | Parameter | Description |
 | --- | --- |
-| storeId | The StoreId the product variants belogn to |
+| storeId | The StoreId the product variants belong to |
 | list | The list to wrap. |
 
 

--- a/content/core/1.7.0/reference/vendr-core-services/iorderservice.md
+++ b/content/core/1.7.0/reference/vendr-core-services/iorderservice.md
@@ -294,7 +294,7 @@ public PagedResult<OrderReadOnly> SearchOrders(IQuerySpecification<OrderReadOnly
 | Parameter | Description |
 | --- | --- |
 | query | The query specification to perform |
-| sort | The sort order specification describinng the sort order in which to return the results |
+| sort | The sort order specification describing the sort order in which to return the results |
 | currentPage | The page of results of which to retrieve |
 | itemsPerPage | The number of items per page to return |
 
@@ -344,7 +344,7 @@ public PagedResult<OrderReadOnly> SearchOrders(
 | Parameter | Description |
 | --- | --- |
 | query | The factory method to generate the query specification to perform |
-| sort | The factory method to generate the sort order specification describinng the sort order in which to return the results |
+| sort | The factory method to generate the sort order specification describing the sort order in which to return the results |
 | currentPage | The page of results of which to retrieve |
 | itemsPerPage | The number of items per page to return |
 

--- a/content/core/1.7.0/reference/vendr-web-propertyeditors/README.md
+++ b/content/core/1.7.0/reference/vendr-web-propertyeditors/README.md
@@ -13,7 +13,7 @@ description: API reference for Vendr.Web.PropertyEditors in Vendr, the eCommerce
 
 | Public Type | Description |
 | --- | --- |
-| class [VariantsEditorComponent](variantseditorcomponent/) | Component to watch for content changes to nodes with a variants editor on them and stash a storeId property in the data structure. This is predominantly for Vendr Deploy which needs to lookup Product Attribute dependencies but needs as storeId to do it however the Umbraco Deploy value connectors don't have any other context other than the property value and it's property type. This may also be true for uSycn too. We could also look to potetially use this in the value converter for the variants editor as we now have this also being store aware. |
+| class [VariantsEditorComponent](variantseditorcomponent/) | Component to watch for content changes to nodes with a variants editor on them and stash a storeId property in the data structure. This is predominantly for Vendr Deploy which needs to lookup Product Attribute dependencies but needs as storeId to do it however the Umbraco Deploy value connectors don't have any other context other than the property value and it's property type. This may also be true for uSycn too. We could also look to potentially use this in the value converter for the variants editor as we now have this also being store aware. |
 | class [VariantsEditorComposer](variantseditorcomposer/) |  |
 | class [VariantsEditorConfiguration](variantseditorconfiguration/) |  |
 | class [VariantsEditorDataConverter](variantseditordataconverter/) |  |

--- a/content/core/1.7.0/reference/vendr-web-propertyeditors/variantseditorcomponent.md
+++ b/content/core/1.7.0/reference/vendr-web-propertyeditors/variantseditorcomponent.md
@@ -4,7 +4,7 @@ description: API reference for VariantsEditorComponent in Vendr, the eCommerce s
 ---
 ## VariantsEditorComponent
 
-Component to watch for content changes to nodes with a variants editor on them and stash a storeId property in the data structure. This is predominantly for Vendr Deploy which needs to lookup Product Attribute dependencies but needs as storeId to do it however the Umbraco Deploy value connectors don't have any other context other than the property value and it's property type. This may also be true for uSycn too. We could also look to potetially use this in the value converter for the variants editor as we now have this also being store aware.
+Component to watch for content changes to nodes with a variants editor on them and stash a storeId property in the data structure. This is predominantly for Vendr Deploy which needs to lookup Product Attribute dependencies but needs as storeId to do it however the Umbraco Deploy value connectors don't have any other context other than the property value and it's property type. This may also be true for uSycn too. We could also look to potentially use this in the value converter for the variants editor as we now have this also being store aware.
 
 ```csharp
 public class VariantsEditorComponent : IComponent


### PR DESCRIPTION
Just a few spelling mistakes I noticed when building checkout.com docs: https://github.com/vendrhub/vendr-documentation/pull/72/checks?check_run_id=2369059542

Value still has some errors/warnings like e.g. `'Prefer JavaScript over \'javascript.\''` and `'Prefer back-office over \'back office.\''`.