### PR TITLE
Wrong v1.8.1 publish date

### DIFF
--- a/content/core/changelog.md
+++ b/content/core/changelog.md
@@ -4,7 +4,7 @@ description: Changelog for the Core Vendr product
 ---
 
 ## v1.8.1  
-**Date:** 2021-05-05    
+**Date:** 2021-05-13    
 **Description:** Patch release with minor bug fixes
 
 --- 


### PR DESCRIPTION
Copy-paste curse? :)
I've found the correct date in NuGet info, but I don't know, if it is really the correct date.

It's a little mistake but may be confusing.